### PR TITLE
A proxy URL with the port number

### DIFF
--- a/src/Asset/ProxyPackages.php
+++ b/src/Asset/ProxyPackages.php
@@ -71,8 +71,14 @@ class ProxyPackages extends Packages
         if ($matchedProxyUrl->getHost() !== null) {
             $requestContext->setHost($matchedProxyUrl->getHost());
         }
-        if ($matchedProxyUrl->getScheme() !== null) {
-            $requestContext->setScheme($matchedProxyUrl->getScheme());
+        $requestContext->setScheme($matchedProxyUrl->getScheme());
+
+        if ($matchedProxyUrl->getPort() !== null) {
+            if ($matchedProxyUrl->getScheme() == 'http') {
+                $requestContext->setHttpPort($matchedProxyUrl->getPort());
+            } elseif ($matchedProxyUrl->getScheme() == 'https') {
+                $requestContext->setHttpsPort($matchedProxyUrl->getPort());
+            }
         }
 
         $urlGenerator = new UrlGenerator($routeCollection, $requestContext);

--- a/src/Asset/ProxyPackages.php
+++ b/src/Asset/ProxyPackages.php
@@ -43,7 +43,7 @@ class ProxyPackages extends Packages
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getUrl($path, $packageName = null)
     {

--- a/src/DependencyInjection/Compiler/ReplaceAssetExtensionAndPakcagesDefinitionPass.php
+++ b/src/DependencyInjection/Compiler/ReplaceAssetExtensionAndPakcagesDefinitionPass.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class ReplaceAssetExtensionAndPakcagesDefinitionPass implements CompilerPassInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {

--- a/src/DependencyInjection/PHPMentorsProxyURLRewriteExtension.php
+++ b/src/DependencyInjection/PHPMentorsProxyURLRewriteExtension.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 class PHPMentorsProxyURLRewriteExtension extends Extension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -35,7 +35,7 @@ class PHPMentorsProxyURLRewriteExtension extends Extension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getAlias()
     {

--- a/src/EventListener/ProxyUrlRewriteListener.php
+++ b/src/EventListener/ProxyUrlRewriteListener.php
@@ -58,19 +58,18 @@ class ProxyUrlRewriteListener
             $matchedProxyUrl = $this->proxyUrlMatcher->match($this->router->getContext()->getPathInfo());
             if ($matchedProxyUrl !== null) {
                 $this->router->getContext()->setBaseUrl($matchedProxyUrl->getPath().$this->router->getContext()->getBaseUrl());
-
-                if ($matchedProxyUrl->getScheme() !== null) {
-                    $this->router->getContext()->setScheme($matchedProxyUrl->getScheme());
-                }
+                $this->router->getContext()->setScheme($matchedProxyUrl->getScheme());
 
                 if ($matchedProxyUrl->getHost() !== null) {
                     $this->router->getContext()->setHost($matchedProxyUrl->getHost());
                 }
 
-                if ($this->router->getContext()->getScheme() == 'http') {
-                    $this->router->getContext()->setHttpPort('80');
-                } elseif ($this->router->getContext()->getScheme() == 'https') {
-                    $this->router->getContext()->setHttpsPort('443');
+                if ($matchedProxyUrl->getPort() !== null) {
+                    if ($this->router->getContext()->getScheme() == 'http') {
+                        $this->router->getContext()->setHttpPort($matchedProxyUrl->getPort());
+                    } elseif ($this->router->getContext()->getScheme() == 'https') {
+                        $this->router->getContext()->setHttpsPort($matchedProxyUrl->getPort());
+                    }
                 }
             }
         }

--- a/src/PHPMentorsProxyURLRewriteBundle.php
+++ b/src/PHPMentorsProxyURLRewriteBundle.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class PHPMentorsProxyURLRewriteBundle extends Bundle
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function build(ContainerBuilder $container)
     {
@@ -28,7 +28,7 @@ class PHPMentorsProxyURLRewriteBundle extends Bundle
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getContainerExtension()
     {

--- a/src/ProxyUrl/ProxyUrl.php
+++ b/src/ProxyUrl/ProxyUrl.php
@@ -45,19 +45,42 @@ class ProxyUrl implements EntityInterface, IdentifiableInterface
     private $target;
 
     /**
+     * @var int
+     *
+     * @since Property available since Release 1.2.0
+     */
+    private $port;
+
+    /**
      * @param int|string $id
      * @param string     $target
      * @param string     $path
      * @param string     $host
      * @param string     $scheme
+     * @param int        $port
      */
-    public function __construct($id, $target, $path, $host, $scheme)
+    public function __construct($id, $target, $path, $host, $scheme, $port)
     {
         $this->id = $id;
         $this->target = $target;
         $this->path = rtrim($path, '/');
         $this->host = $host;
-        $this->scheme = $scheme;
+
+        if ($scheme === null) {
+            $this->scheme = 'http';
+        } else {
+            $this->scheme = $scheme;
+        }
+
+        if ($port === null) {
+            if ($this->scheme == 'http') {
+                $this->port = 80;
+            } elseif ($this->scheme == 'https') {
+                $this->port = 443;
+            }
+        } else {
+            $this->port = $port;
+        }
     }
 
     /**
@@ -102,5 +125,13 @@ class ProxyUrl implements EntityInterface, IdentifiableInterface
     public function getTarget()
     {
         return $this->target;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPort()
+    {
+        return $this->port;
     }
 }

--- a/src/ProxyUrl/ProxyUrl.php
+++ b/src/ProxyUrl/ProxyUrl.php
@@ -92,7 +92,7 @@ class ProxyUrl implements EntityInterface, IdentifiableInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      *
      * @return int|string
      *

--- a/src/ProxyUrl/ProxyUrlCollection.php
+++ b/src/ProxyUrl/ProxyUrlCollection.php
@@ -23,7 +23,7 @@ class ProxyUrlCollection implements EntityCollectionInterface
     private $proxyUrls = array();
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function add(EntityInterface $entity)
     {
@@ -33,7 +33,7 @@ class ProxyUrlCollection implements EntityCollectionInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function count()
     {
@@ -41,7 +41,7 @@ class ProxyUrlCollection implements EntityCollectionInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getIterator()
     {
@@ -49,7 +49,7 @@ class ProxyUrlCollection implements EntityCollectionInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function get($key)
     {
@@ -61,7 +61,7 @@ class ProxyUrlCollection implements EntityCollectionInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function remove(EntityInterface $entity)
     {
@@ -69,7 +69,7 @@ class ProxyUrlCollection implements EntityCollectionInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function toArray()
     {

--- a/src/ProxyUrl/ProxyUrlFactory.php
+++ b/src/ProxyUrl/ProxyUrlFactory.php
@@ -25,9 +25,9 @@ class ProxyUrlFactory implements ServiceInterface
      */
     public function create($proxyUrlId, $path, $proxyUrl)
     {
-        list($proxyUrlPath, $proxyUrlHost, $proxyUrlScheme) = static::parseUrl($proxyUrl);
+        list($proxyUrlPath, $proxyUrlHost, $proxyUrlScheme, $proxyUrlPort) = static::parseUrl($proxyUrl);
 
-        return new ProxyUrl($proxyUrlId, $path, $proxyUrlPath, $proxyUrlHost, $proxyUrlScheme);
+        return new ProxyUrl($proxyUrlId, $path, $proxyUrlPath, $proxyUrlHost, $proxyUrlScheme, $proxyUrlPort);
     }
 
     /**
@@ -46,13 +46,10 @@ class ProxyUrlFactory implements ServiceInterface
             throw new \UnexpectedValueException(sprintf('The proxy URL "%s" is malformed.', $url));
         }
 
-        if (array_key_exists('port', $components)) {
-            throw new \UnexpectedValueException(sprintf('The proxy URL "%s" cannot contain port number.', $url));
-        }
-
         $path = array_key_exists('path', $components) ? $components['path'] : null;
         $host = array_key_exists('host', $components) ? $components['host'] : null;
         $scheme = array_key_exists('scheme', $components) ? $components['scheme'] : null;
+        $port = array_key_exists('port', $components) ? $components['port'] : null;
 
         if (strpos($path, '//') === 0) {
             $endOfHostPosition = strpos($path, '/', 2);
@@ -67,6 +64,6 @@ class ProxyUrlFactory implements ServiceInterface
             }
         }
 
-        return array($path, $host, $scheme);
+        return array($path, $host, $scheme, $port);
     }
 }

--- a/src/Templating/ProxyAssetExtension.php
+++ b/src/Templating/ProxyAssetExtension.php
@@ -20,7 +20,7 @@ use Symfony\Bridge\Twig\Extension\AssetExtension;
 class ProxyAssetExtension extends AssetExtension
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getAssetUrl($path, $packageName = null, $absolute = false, $version = null)
     {

--- a/tests/Functional/UrlRewritingInControllersTest.php
+++ b/tests/Functional/UrlRewritingInControllersTest.php
@@ -77,6 +77,9 @@ class UrlRewritingInControllersTest extends WebTestCase
             array('https://example.com/foo/bar/', UrlGeneratorInterface::ABSOLUTE_PATH, '/foo/bar/url-rewriting-in-controllers/'),
             array('https://example.com/foo/bar/', UrlGeneratorInterface::ABSOLUTE_URL, 'https://example.com/foo/bar/url-rewriting-in-controllers/'),
             array('https://example.com/foo/bar/', UrlGeneratorInterface::NETWORK_PATH, '//example.com/foo/bar/url-rewriting-in-controllers/'),
+            array('http://example.com:8180/foo/bar/', UrlGeneratorInterface::ABSOLUTE_PATH, '/foo/bar/url-rewriting-in-controllers/'),
+            array('http://example.com:8180/foo/bar/', UrlGeneratorInterface::ABSOLUTE_URL, 'http://example.com:8180/foo/bar/url-rewriting-in-controllers/'),
+            array('http://example.com:8180/foo/bar/', UrlGeneratorInterface::NETWORK_PATH, '//example.com:8180/foo/bar/url-rewriting-in-controllers/'),
         );
     }
 

--- a/tests/Functional/UrlRewritingInControllersTest.php
+++ b/tests/Functional/UrlRewritingInControllersTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class UrlRewritingInControllersTest extends WebTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {
@@ -34,7 +34,7 @@ class UrlRewritingInControllersTest extends WebTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function tearDown()
     {
@@ -44,7 +44,7 @@ class UrlRewritingInControllersTest extends WebTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected static function createKernel(array $options = array())
     {

--- a/tests/Functional/UrlRewritingInTemplatesTest.php
+++ b/tests/Functional/UrlRewritingInTemplatesTest.php
@@ -75,6 +75,10 @@ class UrlRewritingInTemplatesTest extends WebTestCase
             array('http://example.com/foo/bar/', true, 'http://example.com/foo/bar/bundles/test/foo.png'),
             array('https://example.com/foo/bar/', false, '/foo/bar/bundles/test/foo.png'),
             array('https://example.com/foo/bar/', true, 'https://example.com/foo/bar/bundles/test/foo.png'),
+            array('http://example.com:8180/foo/bar/', false, '/foo/bar/bundles/test/foo.png'),
+            array('http://example.com:8180/foo/bar/', true, 'http://example.com:8180/foo/bar/bundles/test/foo.png'),
+            array('https://example.com:8180/foo/bar/', false, '/foo/bar/bundles/test/foo.png'),
+            array('https://example.com:8180/foo/bar/', true, 'https://example.com:8180/foo/bar/bundles/test/foo.png'),
         );
     }
 

--- a/tests/Functional/UrlRewritingInTemplatesTest.php
+++ b/tests/Functional/UrlRewritingInTemplatesTest.php
@@ -16,12 +16,11 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class UrlRewritingInTemplatesTest extends WebTestCase
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function setUp()
     {
@@ -34,7 +33,7 @@ class UrlRewritingInTemplatesTest extends WebTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function tearDown()
     {
@@ -44,7 +43,7 @@ class UrlRewritingInTemplatesTest extends WebTestCase
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected static function createKernel(array $options = array())
     {

--- a/tests/Functional/app/AppKernel.php
+++ b/tests/Functional/app/AppKernel.php
@@ -26,7 +26,7 @@ class AppKernel extends Kernel
     private static $numberOfInitializations = 0;
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function registerBundles()
     {
@@ -39,7 +39,7 @@ class AppKernel extends Kernel
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
@@ -59,7 +59,7 @@ class AppKernel extends Kernel
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function getContainerClass()
     {
@@ -67,7 +67,7 @@ class AppKernel extends Kernel
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     protected function initializeContainer()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `master` for new features / `1.1` for fixes
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | BSD-2-Clause

This PR provides a feature that allows you to specify the proxy URL with the port number as the following:
    
```yaml
...
phpmentors_proxy_url_rewrite:
        proxy_urls:
            foo_bar:
                path: "!^.*!"
                proxy_url: "http://www.example.com:8080/foo/bar"
```
