### PR TITLE
New minimum required Symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,20 +13,20 @@
     "require": {
         "php": ">=5.3.9",
         "phpmentors/domain-kata": "~1.4",
-        "symfony/config": "~2.7",
-        "symfony/dependency-injection": "~2.7",
-        "symfony/framework-bundle": "~2.7",
-        "symfony/http-kernel": "~2.7",
-        "symfony/routing": "~2.7"
+        "symfony/config": "~2.8",
+        "symfony/dependency-injection": "~2.8",
+        "symfony/framework-bundle": "~2.8",
+        "symfony/http-kernel": "~2.8",
+        "symfony/routing": "~2.8"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/asset": "~2.7",
-        "symfony/browser-kit": "~2.7",
-        "symfony/filesystem": "~2.7",
-        "symfony/http-foundation": "~2.7",
-        "symfony/twig-bridge": "~2.7",
-        "symfony/twig-bundle": "~2.7"
+        "symfony/asset": "~2.8",
+        "symfony/browser-kit": "~2.8",
+        "symfony/filesystem": "~2.8",
+        "symfony/http-foundation": "~2.8",
+        "symfony/twig-bridge": "~2.8",
+        "symfony/twig-bundle": "~2.8"
     },
     "autoload": {
         "psr-4": {
@@ -39,9 +39,9 @@
         }
     },
     "suggest": {
-        "symfony/asset": ">=2.7.0 provides transparent URL rewriting with the `asset()` function in Twig templates",
-        "symfony/twig-bridge": ">=2.7.0 provides transparent URL rewriting with the `asset()` function in Twig templates",
-        "symfony/twig-bundle": ">=2.7.0 provides transparent URL rewriting with the `asset()` function in Twig templates"
+        "symfony/asset": ">=2.8.0 provides transparent URL rewriting with the `asset()` function in Twig templates",
+        "symfony/twig-bridge": ">=2.8.0 provides transparent URL rewriting with the `asset()` function in Twig templates",
+        "symfony/twig-bundle": ">=2.8.0 provides transparent URL rewriting with the `asset()` function in Twig templates"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `master`
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | BSD-2-Clause

This PR updates the minimum required Symfony version from `2.7` to `2.8`.
