### PR TITLE
Trailing slash redirection support

### DIFF
--- a/src/EventListener/TrailingSlashRedirectionListener.php
+++ b/src/EventListener/TrailingSlashRedirectionListener.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Copyright (c) Atsuhiro Kubo <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsProxyURLRewriteBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\ProxyURLRewriteBundle\EventListener;
+
+use Symfony\Bundle\FrameworkBundle\Controller\RedirectController;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+
+/**
+ * @since Class available since Release 1.4.0
+ */
+class TrailingSlashRedirectionListener
+{
+    public function onKernelController(FilterControllerEvent $event)
+    {
+        $controller = $event->getController();
+        if (is_array($controller) && ($controller[0] instanceof RedirectController) && $controller[1] == 'urlRedirectAction') {
+            $request = $event->getRequest();
+            if ($request->attributes->has('_route')) {
+                $request->attributes->set('request', $request);
+                $request->attributes->set('route', $request->attributes->get('_route'));
+                $request->attributes->set('ignoreAttributes', array('path', 'scheme', 'httpPort', 'httpsPort'));
+                $event->setController(array($controller[0], 'redirectAction'));
+            }
+        }
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,6 +7,7 @@
     <parameter key="phpmentors_proxy_url_rewrite.proxy_url_factory.class">PHPMentors\ProxyURLRewriteBundle\ProxyUrl\ProxyUrlFactory</parameter>
     <parameter key="phpmentors_proxy_url_rewrite.proxy_url_matcher.class">PHPMentors\ProxyURLRewriteBundle\ProxyUrl\ProxyUrlMatcher</parameter>
     <parameter key="phpmentors_proxy_url_rewrite.proxy_url_rewrite_listener.class">PHPMentors\ProxyURLRewriteBundle\EventListener\ProxyUrlRewriteListener</parameter>
+    <parameter key="phpmentors_proxy_url_rewrite.trailing_slash_redirection_listener.class">PHPMentors\ProxyURLRewriteBundle\EventListener\TrailingSlashRedirectionListener</parameter>
   </parameters>
   <services>
     <service id="phpmentors_proxy_url_rewrite.proxy_packages" class="%phpmentors_proxy_url_rewrite.proxy_packages.class%" public="false">
@@ -30,6 +31,9 @@
         <argument type="service" id="router"/>
       </call>
       <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="16"/>
+    </service>
+    <service id="phpmentors_proxy_url_rewrite.trailing_slash_redirection_listener" class="%phpmentors_proxy_url_rewrite.trailing_slash_redirection_listener.class%">
+      <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController"/>
     </service>
   </services>
 </container>

--- a/tests/Functional/AbstractTestCase.php
+++ b/tests/Functional/AbstractTestCase.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Copyright (c) Atsuhiro Kubo <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsProxyURLRewriteBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\ProxyURLRewriteBundle\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @since Class available since Release 1.4.0
+ */
+abstract class AbstractTestCase extends WebTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $_SERVER['KERNEL_DIR'] = __DIR__.'/app';
+        require_once $_SERVER['KERNEL_DIR'].'/AppKernel.php';
+        $_SERVER['KERNEL_CLASS'] = 'AppKernel';
+
+        if (self::$kernel !== null) {
+            $this->removeCacheDir(self::$kernel->getCacheDir());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        if (self::$kernel !== null) {
+            $this->removeCacheDir(self::$kernel->getCacheDir());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static function createKernel(array $options = array())
+    {
+        $kernel = KernelTestCase::createKernel($options);
+        if (array_key_exists('config', $options)) {
+            $kernel->setConfig($options['config']);
+        }
+
+        return $kernel;
+    }
+
+    protected function removeCacheDir($cacheDir)
+    {
+        $fileSystem = new Filesystem();
+        $fileSystem->remove($cacheDir);
+    }
+}

--- a/tests/Functional/Bundle/TestBundle/Controller/TrailingSlashRedirectionController.php
+++ b/tests/Functional/Bundle/TestBundle/Controller/TrailingSlashRedirectionController.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * Copyright (c) Atsuhiro Kubo <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsProxyURLRewriteBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\ProxyURLRewriteBundle\Functional\Bundle\TestBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @since Class available since Release 1.4.0
+ */
+class TrailingSlashRedirectionController extends Controller
+{
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function indexAction(Request $request)
+    {
+        return new Response();
+    }
+}

--- a/tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -7,3 +7,13 @@ test_url_rewriting_in_templates_index:
     path: /url-rewriting-in-templates/
     defaults: { _controller: "TestBundle:UrlRewritingInTemplates:index" }
     methods: [GET]
+
+test_trailing_slash_redirection_with_slash_index:
+    path: /trailing-slash-redirection-with-slash/
+    defaults: { _controller: "TestBundle:TrailingSlashRedirection:index" }
+    methods: [GET]
+
+test_trailing_slash_redirection_without_slash_index:
+    path: /trailing-slash-redirection-without-slash
+    defaults: { _controller: "TestBundle:TrailingSlashRedirection:index" }
+    methods: [GET]

--- a/tests/Functional/HostFilterTest.php
+++ b/tests/Functional/HostFilterTest.php
@@ -12,60 +12,14 @@
 
 namespace PHPMentors\ProxyURLRewriteBundle\Functional;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @since Class available since Release 1.2.0
  */
-class HostFilterTest extends WebTestCase
+class HostFilterTest extends AbstractTestCase
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $_SERVER['KERNEL_DIR'] = __DIR__.'/app';
-        require_once $_SERVER['KERNEL_DIR'].'/AppKernel.php';
-        $_SERVER['KERNEL_CLASS'] = 'AppKernel';
-
-        $this->removeCacheDir();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $this->removeCacheDir();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected static function createKernel(array $options = array())
-    {
-        $kernel = KernelTestCase::createKernel($options);
-        if (array_key_exists('config', $options)) {
-            $kernel->setConfig($options['config']);
-        }
-
-        return $kernel;
-    }
-
-    protected function removeCacheDir()
-    {
-        $fileSystem = new Filesystem();
-        $fileSystem->remove($_SERVER['KERNEL_DIR'].'/cache/test');
-    }
-
     public function filterData()
     {
         return array(

--- a/tests/Functional/TrailingSlashRedirectionTest.php
+++ b/tests/Functional/TrailingSlashRedirectionTest.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright (c) Atsuhiro Kubo <kubo@iteman.jp>,
+ * All rights reserved.
+ *
+ * This file is part of PHPMentorsProxyURLRewriteBundle.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\ProxyURLRewriteBundle\Functional;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * @since Class available since Release 1.4.0
+ */
+class TrailingSlashRedirectionTest extends AbstractTestCase
+{
+    public function redirectWithProxyUrlData()
+    {
+        $data = array(
+            array('/trailing-slash-redirection-with-slash', true, 'http://www.example.com/foo/trailing-slash-redirection-with-slash/'),
+            array('/trailing-slash-redirection-with-slash/', false, null),
+            array('/trailing-slash-redirection-without-slash', false, null),
+        );
+
+        if (Kernel::VERSION_ID >= 40000) {
+            $data[] = array('/trailing-slash-redirection-without-slash/', true, 'http://www.example.com/foo/trailing-slash-redirection-without-slash');
+        }
+
+        return $data;
+    }
+
+    /**
+     * @test
+     * @dataProvider redirectWithProxyUrlData
+     */
+    public function redirectWithProxyUrl($pathToBeRequested, $redirection, $urlToBeRedirected)
+    {
+        $proxyUrl = 'http://www.example.com/foo';
+        $client = $this->createClient(array('config' => function (ContainerBuilder $container) use ($proxyUrl) {
+            $container->loadFromExtension('framework', array(
+                'secret' => '$ecret',
+            ));
+            $container->loadFromExtension('phpmentors_proxy_url_rewrite', array(
+                'proxy_urls' => array(
+                    'foo' => array(
+                        'path' => '!^.*!',
+                        'proxy_url' => $proxyUrl,
+                    ),
+                ),
+            ));
+        }));
+
+        $client->request('GET', 'http://backend1.example.com:8080'.$pathToBeRequested);
+
+        if ($redirection) {
+            $this->assertThat($client->getResponse()->getStatusCode(), $this->equalTo(301), $client->getResponse()->getContent());
+            $this->assertThat($client->getResponse()->headers->get('Location'), $this->equalTo($urlToBeRedirected));
+        } else {
+            $this->assertThat($client->getResponse()->getStatusCode(), $this->equalTo(200), $client->getResponse()->getContent());
+        }
+    }
+}

--- a/tests/Functional/UrlRewritingInControllersTest.php
+++ b/tests/Functional/UrlRewritingInControllersTest.php
@@ -12,57 +12,11 @@
 
 namespace PHPMentors\ProxyURLRewriteBundle\Functional;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class UrlRewritingInControllersTest extends WebTestCase
+class UrlRewritingInControllersTest extends AbstractTestCase
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $_SERVER['KERNEL_DIR'] = __DIR__.'/app';
-        require_once $_SERVER['KERNEL_DIR'].'/AppKernel.php';
-        $_SERVER['KERNEL_CLASS'] = 'AppKernel';
-
-        $this->removeCacheDir();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $this->removeCacheDir();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected static function createKernel(array $options = array())
-    {
-        $kernel = KernelTestCase::createKernel($options);
-        if (array_key_exists('config', $options)) {
-            $kernel->setConfig($options['config']);
-        }
-
-        return $kernel;
-    }
-
-    protected function removeCacheDir()
-    {
-        $fileSystem = new Filesystem();
-        $fileSystem->remove($_SERVER['KERNEL_DIR'].'/cache/test');
-    }
-
     public function rewriteUrlInGenerateUrlData()
     {
         return array(

--- a/tests/Functional/UrlRewritingInTemplatesTest.php
+++ b/tests/Functional/UrlRewritingInTemplatesTest.php
@@ -12,56 +12,10 @@
 
 namespace PHPMentors\ProxyURLRewriteBundle\Functional;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Filesystem\Filesystem;
 
-class UrlRewritingInTemplatesTest extends WebTestCase
+class UrlRewritingInTemplatesTest extends AbstractTestCase
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $_SERVER['KERNEL_DIR'] = __DIR__.'/app';
-        require_once $_SERVER['KERNEL_DIR'].'/AppKernel.php';
-        $_SERVER['KERNEL_CLASS'] = 'AppKernel';
-
-        $this->removeCacheDir();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $this->removeCacheDir();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected static function createKernel(array $options = array())
-    {
-        $kernel = KernelTestCase::createKernel($options);
-        if (array_key_exists('config', $options)) {
-            $kernel->setConfig($options['config']);
-        }
-
-        return $kernel;
-    }
-
-    protected function removeCacheDir()
-    {
-        $fileSystem = new Filesystem();
-        $fileSystem->remove($_SERVER['KERNEL_DIR'].'/cache/test');
-    }
-
     /**
      * @return array
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | BSD-2-Clause

This PR adds support for trailing slash redirection https://symfony.com/doc/current/routing.html#routing-trailing-slash-redirection.

As of this, any internal URLs to be redirerected will be with proxy URL.